### PR TITLE
Unknown exception handler

### DIFF
--- a/src/communex/errors.py
+++ b/src/communex/errors.py
@@ -14,6 +14,10 @@ class NetworkTimeoutError(NetworkError):
     """Timeout error"""
 
 
+class ClientConnectionError(NetworkError):
+    """Client connection error"""
+
+
 class PasswordError(Exception):
     """Password related error."""
 

--- a/src/communex/module/client.py
+++ b/src/communex/module/client.py
@@ -71,6 +71,8 @@ class ModuleClient:
             raise NetworkTimeoutError(
                 f"The call took longer than the timeout of {timeout} second(s)"
             ).with_traceback(e.__traceback__)
+        except Exception as e:
+            print(e)
 
 
 if __name__ == "__main__":

--- a/src/communex/module/client.py
+++ b/src/communex/module/client.py
@@ -11,7 +11,7 @@ import aiohttp.client_exceptions
 import aiohttp.web_exceptions
 from substrateinterface import Keypair
 
-from communex.errors import NetworkTimeoutError
+from communex.errors import NetworkTimeoutError, ClientConnectionError
 from communex.key import check_ss58_address
 from communex.types import Ss58Address
 
@@ -71,8 +71,12 @@ class ModuleClient:
             raise NetworkTimeoutError(
                 f"The call took longer than the timeout of {timeout} second(s)"
             ).with_traceback(e.__traceback__)
+        except aiohttp.client_exceptions.ClientConnectorError as e:
+            raise ClientConnectionError(
+                f"The server is not listening on {self.host}:{self.port}"
+            )
         except Exception as e:
-            print(e)
+            raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I got this error while running a template validator.
Now I fixed this error and it was due to the missing exception handler in client.py.

```2024-12-22 00:08:41,927 - src.utils.utils - ERROR - Miner 0.0.0.0:9960 failed to generate an answer
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 1109, in _wrap_create_connection
    sock = await aiohappyeyeballs.start_connection(
  File "/usr/lib/python3.10/site-packages/aiohappyeyeballs/impl.py", line 104, in start_connection
    raise first_exception
  File "/usr/lib/python3.10/site-packages/aiohappyeyeballs/impl.py", line 82, in start_connection
    sock = await _connect_sock(
  File "/usr/lib/python3.10/site-packages/aiohappyeyeballs/impl.py", line 174, in _connect_sock
    await loop.sock_connect(sock, address)
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 501, in sock_connect
    return await fut
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 541, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('0.0.0.0', 9960)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../src/validator/base_validator.py", line 244, in _get_miner_prediction
    response = asyncio.run(
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/usr/lib/python3.10/site-packages/communex/module/client.py", line 46, in call
    async with session.post(
  File "/usr/lib/python3.10/site-packages/aiohttp/client.py", line 1423, in __aenter__
    self._resp: _RetType = await self._coro
  File "/usr/lib/python3.10/site-packages/aiohttp/client.py", line 701, in _request
    conn = await self._connector.connect(
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 544, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 1050, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 1394, in _create_direct_connection
    raise last_exc
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 1363, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
  File "/usr/lib/python3.10/site-packages/aiohttp/connector.py", line 1124, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host 0.0.0.0:9960 ssl:default [Connect call failed ('0.0.0.0', 9960)]```